### PR TITLE
932646: Enhancing the UI for a More Attractive Stock Management Application with tailwind3.

### DIFF
--- a/src/components/Overview.tsx
+++ b/src/components/Overview.tsx
@@ -258,7 +258,7 @@ export default function Overview(props: { changeMarquee: Function, myStockDm: Da
                 <ColumnDirective
                   field="CompanyName"
                   headerText="Company"
-                  width="170"
+                  width="160"
                 ></ColumnDirective>
                 <ColumnDirective
                   field="Sector"
@@ -276,21 +276,21 @@ export default function Overview(props: { changeMarquee: Function, myStockDm: Da
                   field="Last"
                   format="N2"
                   textAlign="Center"
-                  width="90"
+                  width="80"
                 ></ColumnDirective>
                 <ColumnDirective
                   field="ChangeInValue"
                   headerText="CHNG 1D"
                   format="N2"
                   textAlign="Center"
-                  width="100"
+                  width="90"
                 ></ColumnDirective>
                 <ColumnDirective
                   field="ChangeInPercent"
                   headerText="CHNG (%)"
                   format="P2"
                   textAlign="Center"
-                  width="100"
+                  width="80"
                 ></ColumnDirective>
                 <ColumnDirective
                   field="Rating"
@@ -301,13 +301,13 @@ export default function Overview(props: { changeMarquee: Function, myStockDm: Da
                   field="High"
                   format="N2"
                   textAlign="Center"
-                  width="90"
+                  width="80"
                 ></ColumnDirective>
                 <ColumnDirective
                   field="Low"
                   format="N2"
                   textAlign="Center"
-                  width="90"
+                  width="80"
                 ></ColumnDirective>
                 <ColumnDirective
                   field="Volume"
@@ -332,7 +332,7 @@ export default function Overview(props: { changeMarquee: Function, myStockDm: Da
                       },
                     },
                   ]}
-                  width="110"
+                  width="100"
                 ></ColumnDirective>
               </ColumnsDirective>
               <Inject services={[Page, Sort, CommandColumn]} />
@@ -344,7 +344,7 @@ export default function Overview(props: { changeMarquee: Function, myStockDm: Da
         id="listSidebar"
         ref={sidebarobj}
         className="sidebar-list"
-        width="250px"
+        width="220px"
         target=".listmaincontent"
         type="Auto"
         isOpen={true}


### PR DESCRIPTION
### Bug description

On the **npmci** site, the **Smart Stock Picks** section has a scrollbar even at 100% browser size with the recommended screen resolution of 125%.

### Root cause

NA

### Reason for not identifying earlier

Find how it was missed in our earlier testing and development by analyzing the below checklist. This will help prevent similar mistakes in the future.

- [ ] Guidelines/documents are not followed

- Common guidelines / Core team guideline

- Specification document

- Requirement document

- [x] Guidelines/documents are not given

- Common guidelines / Core team guideline

- Specification document

- Requirement document

### Reason:

Guidelines/documents are not given - Requirement document

### Action taken:

NA

### Related areas:

theme

### Is it a breaking issue?

NA

### Solution description

On the **npmci** site, the **Smart Stock Picks** section has a scrollbar even at 100% browser size with the recommended screen resolution of 125%, and the solution is to decrease the grid height to prevent it.

### Output screenshots

Before
![image](https://github.com/user-attachments/assets/f1081c5e-752b-4829-a105-a8c1957734b1)

After
![image](https://github.com/user-attachments/assets/14557bb1-6cf8-4d8a-8041-57313905f045)

### Areas affected and ensured

Ensured screen resolution at **150%** and **125%**, tested with browser sizes **100%**, **110%**, and **125%**.

### Additional checklist

This may vary for different teams or products. Check with your scrum masters.

- Did you run the automation against your fix? - NA

- Is there any API name change? - NA

- Is there any existing behavior change of other features due to this code change? - NA

- Does your new code introduce new warnings or binding errors? - NA

- Does your code pass all FxCop and StyleCop rules? - NA

- Did you record this case in the unit test or UI test? - NA

- This issue applicable for blazor? - No